### PR TITLE
Make checkStorageTemplate() Work On Win &Linux

### DIFF
--- a/library/wpos/models/DbUpdater.php
+++ b/library/wpos/models/DbUpdater.php
@@ -72,12 +72,18 @@ class DbUpdater {
 
     public function checkStorageTemplate(){
         // set permissions
-        exec('chmod -R 774 '.$_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'docs/');
-        exec('chmod 774 '.$_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'library/wpos/config.json');
-        // copy docs template if it doesn't exist
-        if (file_exists($_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'docs/logs')==false){
-           exec('cp -a "'.$_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'docs-template/." "'.$_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'docs/"');
-        }
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+			if (file_exists($_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'docs/logs')==false){
+			   exec('ROBOCOPY "'.$_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'docs-template/." "'.$_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'docs/ /E"'); // Need to test out, need to change slash for windows paths?
+			}
+		} else { //  Assume Linux
+			exec('chmod -R 774 '.$_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'docs/');
+			exec('chmod 774 '.$_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'library/wpos/config.json');
+			// copy docs template if it doesn't exist
+			if (file_exists($_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'docs/logs')==false){
+			   exec('cp -a "'.$_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'docs-template/." "'.$_SERVER['DOCUMENT_ROOT'].$_SERVER['APP_ROOT'].'docs/"');
+			}
+		}    
     }
 
     public function upgrade($version, $authneeded=true){


### PR DESCRIPTION
Added OS checking and commands to make it work on Windows & Linux.

The problem with Windows is that the commands can change when Windows version changes (although it is seldom), whereas Linux, the bash commands are pretty much stable.