### PR TITLE
Fix Issue 35 - select2 Problem

### DIFF
--- a/admin/content/invoices.php
+++ b/admin/content/invoices.php
@@ -198,8 +198,9 @@
         WPOS.customers.setCustomers(data['customers/get']);
         WPOS.transactions.setTransactions(data['invoices/get']);
         var customers = WPOS.customers.getCustomers();
+        $('select#ninvcustid.select2-offscreen').find('option').remove().end();
         for (var c in customers){
-            $("#ninvcustid").append('<option data-value="'+c+'" value="'+c+'">'+customers[c].name+'</option>');
+            $("select#ninvcustid.select2-offscreen").append('<option data-value="'+c+'" value="'+c+'">'+customers[c].name+'</option>');
         }
         var invoices = WPOS.transactions.getTransactions();
         var itemarray = [];


### PR DESCRIPTION
Make select2 clear & reload when new customer added.

Previously, after new customer is added, it does not appear in invoice customer selection dropdown, unless site is refreshed. Added code to fix it. There were so many proposed solutions in SO, none of them worked in this case, but provided some hints especially the select2-offscreen class.