### PR TITLE
Fix part of problem in issue 45 (remove order error in  POS)

### DIFF
--- a/assets/js/wpos/sales.js
+++ b/assets/js/wpos/sales.js
@@ -966,7 +966,7 @@ function WPOSSales() {
                 alert("Could not delete the order!");
             }
             WPOS.util.hideLoader();
-            WPOS.trans.showTransactionTable();
+            WPOS.trans.showTransactionView();
         }
     };
 


### PR DESCRIPTION
https://github.com/micwallace/wallacepos/issues/45

seems like WPOS.trans.showTransactionTable() is not longer valid, using WPOS.trans.showTransactionView() instead...