### PR TITLE
Specify $result['data'] as an array before loop

### DIFF
--- a/api/wpos.php
+++ b/api/wpos.php
@@ -110,6 +110,7 @@ if ($_REQUEST['a']!=="multi"){
         $result['error'] = "No API request data provided";
         returnResult($result);
     }
+    $result['data']=array();
     // loop through each request, stop & return the first error if encountered
     foreach ($requests as $action=>$data){
         if ($data==null) {


### PR DESCRIPTION
You need to specify that the $result['data'] is an array before assign value. If not you get A "WARNING: Illegal string offset" in the multi API call.