### PR TITLE
Fix validation for partially returned refunds

### DIFF
--- a/assets/js/wpos/sales.js
+++ b/assets/js/wpos/sales.js
@@ -1377,6 +1377,11 @@ function WPOSSales() {
                 var ritems = sale.refunddata[key].items;
                 // loop through items of the refund and add to total if the id equals
                 for (var key1 in ritems){
+                    // when ritem does not have id but ref
+                    if(!ritems[key1].id && ritems[key1].ref){
+                        refnum += (ritems[key1].ref == items[i].ref?1:0);
+                        continue;
+                    }
                     refnum += (ritems[key1].id == itemid?1:0);
                 }
             }

--- a/assets/js/wpos/sales.js
+++ b/assets/js/wpos/sales.js
@@ -1379,10 +1379,10 @@ function WPOSSales() {
                 for (var key1 in ritems){
                     // when ritem does not have id but ref
                     if(!ritems[key1].id && ritems[key1].ref){
-                        refnum += (ritems[key1].ref == items[i].ref?1:0);
+                        refnum += (ritems[key1].ref == items[i].ref?(parseInt(ritems[key1].numreturned) || 1):0);
                         continue;
                     }
-                    refnum += (ritems[key1].id == itemid?1:0);
+                    refnum += (ritems[key1].id == itemid?(parseInt(ritems[key1].numreturned) || 1):0);
                 }
             }
             refitems.append('<tr>' +


### PR DESCRIPTION
e.g: in a sale of 10 items where 4 items have already been returned and you enter refund qty greater than 6 error message is displayed (but works if you give greater 10 as qty). The feature is already there but it appears that there is a small bug in there, (could be because `items` column of `sale_voids` table doesn't save `id` but `ref`